### PR TITLE
Fix error on missing close_function

### DIFF
--- a/aswitch.py
+++ b/aswitch.py
@@ -107,7 +107,7 @@ class Switch(object):
             if state != self.switchstate:
                 # State has changed: act on it now.
                 self.switchstate = state
-                if state == 0 and self.close_func:
+                if state == 0 and self._close_func:
                     launch(self._close_func, self._close_args)
                 elif state == 1 and self._open_func:
                     launch(self._open_func, self._open_args)


### PR DESCRIPTION
This PR fixes the following bug:
There will be an error if no close_function has been defined due to missing `self._close_args`. This error origins in checking for `self.close_function` instead of `self._close_function`.