### PR TITLE
Prevent queue overflow, smaller code

### DIFF
--- a/aswitch.py
+++ b/aswitch.py
@@ -135,9 +135,6 @@ class Pushbutton:
         ticks_diff = time.ticks_diff
         ticks_ms = time.ticks_ms
         ###
-        # Note: Using explicit "if var is True/False" instead of "if (not) var"
-        #       because it is a bit faster
-        ###
         while True:
             state = raw()
             if state is False and self.state is False and self._supp and \


### PR DESCRIPTION
When using your Pushbutton implementation I noticed that my devices quickly get to an uasyncio queue overflow error when triggering the button rapidly. 
Therefore I rewrote the Pushbutton implementation without the Delay_ms class. 
Now it only uses a single coroutine and will therefore never cause a queue overflow. As a side-effect it also saves ~300Bytes of RAM as frozen module and ~1.5kB as .py file. 

The functionality is exactly the same and I tested all 32 possibilities created by the options:
- suppress
- pressed_function
- released_function
- double_click_function
- long_press_function


I know you probably won't merge it with Delay_ms removed and may have good reasons to stick to the Delay_ms implementation regardless but I did like to provide a safer alternative.