### PR TITLE
Use correct variable

### DIFF
--- a/roundrobin.py
+++ b/roundrobin.py
@@ -25,7 +25,7 @@ async def foo(n):
 
 
 async def main(delay):
-    print('Testing for {} seconds'.format(period))
+    print('Testing for {} seconds'.format(delay))
     await asyncio.sleep(delay)
 
 


### PR DESCRIPTION
Hi, Peter!

This is just a small fix. Won't change how the code runs at all, but might avoid confusion and error if the code is changed or used in other context, e.g.: `loop.run_until_complete(main(period*2))`