### PR TITLE
Default pin state

### DIFF
--- a/v3/docs/DRIVERS.md
+++ b/v3/docs/DRIVERS.md
@@ -112,8 +112,9 @@ on press, release, double-click or long press events.
 
 This can support normally open or normally closed switches, connected to `gnd`
 (with a pullup) or to `3V3` (with a pull-down). The `Pin` object should be
-initialised appropriately. The assumption is that on instantiation the button
-is not pressed.
+initialised appropriately. The default state of the switch can be passed in the
+optional "sense" parameter on the constructor, otherwise the assumption is that
+on instantiation the button is not pressed.
 
 The Pushbutton class uses logical rather than physical state: a button's state
 is considered `True` if pressed, otherwise `False` regardless of its physical
@@ -130,6 +131,8 @@ Constructor arguments:
  1. `pin` Mandatory. The initialised Pin instance.
  2. `suppress` Default `False`. See
  [section 4.1.1](./DRIVERS.md#411-the-suppress-constructor-argument).
+ 3. `sense` Default `None`. See
+ [section 4.1.1](./DRIVERS.md#412-the-sense-constructor-argument).
 
 Methods:
 
@@ -197,6 +200,14 @@ set, `release_func` will be launched as follows:
  launched, `release_func` will not be launched.
  4. If `double_func` exists and a double click occurs, `release_func` will not
  be launched.
+
+### 4.1.2 The sense constructor argument
+
+When the pin value changes, the new value is compared with `sense` to determine
+if the button is closed or open. This is to allow the designer to specify if
+the `closed` state of the button is active `high` or active `low`.
+
+This parameter will default to the current value of `pin` for convienence.
 
 
 # 5. primitives.aadc

--- a/v3/primitives/pushbutton.py
+++ b/v3/primitives/pushbutton.py
@@ -15,7 +15,7 @@ class Pushbutton:
     debounce_ms = 50
     long_press_ms = 1000
     double_click_ms = 400
-    def __init__(self, pin, suppress=False):
+    def __init__(self, pin, suppress=False, sense=None):
         self.pin = pin # Initialise for input
         self._supp = suppress
         self._dblpend = False  # Doubleclick waiting for 2nd click
@@ -26,7 +26,7 @@ class Pushbutton:
         self._lf = False
         self._ld = False  # Delay_ms instance for long press
         self._dd = False  # Ditto for doubleclick
-        self.sense = pin.value()  # Convert from electrical to logical value
+        self.sense = pin.value() if sense is None else sense  # Convert from electrical to logical value
         self.state = self.rawstate()  # Initial state
         asyncio.create_task(self.buttoncheck())  # Thread runs forever
 


### PR DESCRIPTION
Added a default state to the class constructor to allow for a defined default state.

Using the state of a switch at initialisation can lead to spurious results, for example a door switch with the door open as system restart. This could cause the behaviour to be the inverse of what is expected.

