### PR TITLE
Fixes incorrect clearing of old states in queue's event objects

### DIFF
--- a/v3/primitives/queue.py
+++ b/v3/primitives/queue.py
@@ -33,8 +33,8 @@ class Queue:
     async def get(self):  #  Usage: item = await queue.get()
         if self.empty():
             # Queue is empty, put the calling Task on the waiting queue
-            await self._evput.wait()
             self._evput.clear()
+            await self._evput.wait()
         return self._get()
 
     def get_nowait(self):  # Remove and return an item from the queue.
@@ -50,8 +50,8 @@ class Queue:
     async def put(self, val):  # Usage: await queue.put(item)
         if self.qsize() >= self.maxsize and self.maxsize:
             # Queue full
-            await self._evget.wait()
             self._evget.clear()
+            await self._evget.wait()
             # Task(s) waiting to get from queue, schedule first Task
         self._put(val)
 


### PR DESCRIPTION
Queue utilizes events to wait for a new element to be added if queue was empty or wait for an element to be removed before putting a new one if it was full.

However, events can be set for previous iterations and not cleared correctly, causing either exceptions (get case) or "overflow" queue for putting with size limited queues.. See   https://github.com/peterhinch/micropython-async/issues/40 for more details.

Based on the discussion there, I propose to just shift the 'clear'-calls already present by one line. We don't really care about the event state anywhere but in those locations, thus having some old state left, isn't too bad. We don't check/require it elsewhere.

TBH. I feel like it would be nice to have the event object actually have a function call "clear_and_wait", but that might be unreasonable elsewhere. Thus this fix for now.