### PR TITLE
iorw-py: fix typo in comment

### DIFF
--- a/v3/as_demos/iorw.py
+++ b/v3/as_demos/iorw.py
@@ -62,7 +62,7 @@ class MyIO(io.IOBase):
 
     # Test of device that produces one character at a time
     def readline(self):
-        self.ready_rd = False  # Cleared by timer cb do_input
+        self.ready_rd = False  # Set by timer cb do_input
         ch = self.rbuf[self.ridx]
         if ch == ord('\n'):
             self.ridx = 0


### PR DESCRIPTION
The comment being modified by this PR currently states that timer cb `do_input` clears `ready_rd` but it actually sets it.