### PR TITLE
fixed typo in encoder.py primitive

### DIFF
--- a/v3/primitives/encoder.py
+++ b/v3/primitives/encoder.py
@@ -18,7 +18,7 @@ class Encoder:
         self._pin_y = pin_y
         self._v = 0  # Hardware value always starts at 0
         self._cv = v  # Current (divided) value
-        if ((vmin is not None) and v < min) or ((vmax is not None) and v > vmax):
+        if ((vmin is not None) and v < vmin) or ((vmax is not None) and v > vmax):
             raise ValueError('Incompatible args: must have vmin <= v <= vmax')
         self._tsf = asyncio.ThreadSafeFlag()
         trig = Pin.IRQ_RISING | Pin.IRQ_FALLING


### PR DESCRIPTION
This was causing encoder.py to fail on import when vmin was set