### PR TITLE
ESwitch: fire close event when _state goes high

### DIFF
--- a/v3/primitives/events.py
+++ b/v3/primitives/events.py
@@ -72,7 +72,7 @@ class ESwitch:
         while True:
             if (s := self._pin() ^ self._lopen) != self._state:  # 15μs
                 self._state = s
-                self._of() if s else self._cf()
+                self._cf() if s else self._of()
             await asyncio.sleep_ms(dt)  # Wait out bounce
 
     def _of(self):


### PR DESCRIPTION
A state transition from 0 to 1 should fire the `close` event and vice-versa - the comments in the code mention a normally open switch - ie. open = not pressed = inactive = 0. Alternatively language other than open/close might such as activate or deactivate might fit better