### PR TITLE
v3/primitives/__init__.py: Fix classname and module name in lazy loader

### DIFF
--- a/v3/primitives/__init__.py
+++ b/v3/primitives/__init__.py
@@ -35,7 +35,7 @@ _attrs = {
     "Barrier": "barrier",
     "Condition": "condition",
     "Delay_ms": "delay_ms",
-    "Encode": "encoder_async",
+    "Encoder": "encoder",
     "Pushbutton": "pushbutton",
     "ESP32Touch": "pushbutton",
     "Queue": "queue",


### PR DESCRIPTION
This PR fixes the reference to Encoder in `v3/primitives/__init__.py`.