### PR TITLE
Sched: Rework to use UTC functions

### DIFF
--- a/v3/as_drivers/sched/asynctest.py
+++ b/v3/as_drivers/sched/asynctest.py
@@ -5,17 +5,17 @@
 
 import asyncio
 from sched.sched import schedule
-from time import localtime
+from time import gmtime
 
 
 def foo(txt):  # Demonstrate callback
-    yr, mo, md, h, m, s, wd = localtime()[:7]
+    yr, mo, md, h, m, s, wd = gmtime()[:7]
     fst = "Callback {} {:02d}:{:02d}:{:02d} on {:02d}/{:02d}/{:02d}"
     print(fst.format(txt, h, m, s, md, mo, yr))
 
 
 async def bar(txt):  # Demonstrate coro launch
-    yr, mo, md, h, m, s, wd = localtime()[:7]
+    yr, mo, md, h, m, s, wd = gmtime()[:7]
     fst = "Coroutine {} {:02d}:{:02d}:{:02d} on {:02d}/{:02d}/{:02d}"
     print(fst.format(txt, h, m, s, md, mo, yr))
     await asyncio.sleep(0)
@@ -30,7 +30,9 @@ async def main():
     # Launch a coroutine
     asyncio.create_task(schedule(bar, "every 3 mins", hrs=None, mins=range(0, 60, 3)))
 
-    asyncio.create_task(schedule(foo, "one shot", hrs=None, mins=range(0, 60, 2), times=1))
+    asyncio.create_task(
+        schedule(foo, "one shot", hrs=None, mins=range(0, 60, 2), times=1)
+    )
     await asyncio.sleep(900)  # Quit after 15 minutes
 
 

--- a/v3/as_drivers/sched/cron.py
+++ b/v3/as_drivers/sched/cron.py
@@ -8,11 +8,52 @@
 # It holds no state.
 # See docs for restrictions and limitations.
 
-from time import mktime, localtime
+from time import gmtime
+
 # Validation
-_valid = ((0, 59, 'secs'), (0, 59, 'mins'), (0, 23, 'hrs'),
-          (1, 31, 'mday'), (1, 12, 'month'), (0, 6, 'wday'))
-_mdays = {2:28, 4:30, 6:30, 9:30, 11:30}
+_valid = (
+    (0, 59, "secs"),
+    (0, 59, "mins"),
+    (0, 23, "hrs"),
+    (1, 31, "mday"),
+    (1, 12, "month"),
+    (0, 6, "wday"),
+)
+
+
+def is_leap_year(year):
+    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
+
+
+def days_in_month(month, year=gmtime()[0]):
+    if month == 2:
+        return 29 if is_leap_year(year) else 28
+    elif month in [4, 6, 9, 11]:
+        return 30
+    else:
+        return 31
+
+
+def timegm(time_tuple):
+    """Calculate Unix timestamp from UTC."""
+
+    yr, mo, md, h, m, s = time_tuple[:6]
+
+    # calculate days since epoch
+    days = 0
+    for y in range(1970, yr):
+        days += 366 if is_leap_year(y) else 365
+    for mot in range(1, mo):
+        days += days_in_month(mot, yr)
+    days += md - 1
+
+    hours = days * 24 + h
+    minutes = hours * 60 + m
+    seconds = minutes * 60 + s
+
+    return seconds
+
+
 # A call to the inner function takes 270-520μs on Pyboard depending on args
 def cron(*, secs=0, mins=0, hrs=3, mday=None, month=None, wday=None):
     # Given an arg and current value, return offset between arg and cv
@@ -27,18 +68,18 @@ def cron(*, secs=0, mins=0, hrs=3, mday=None, month=None, wday=None):
         except ValueError:  # wrap-round
             return min(a) - cv  # -ve
         except TypeError:
-            raise ValueError('Invalid argument type', type(a))
+            raise ValueError("Invalid argument type", type(a))
 
     if secs is None:  # Special validation for seconds
-        raise ValueError('Invalid None value for secs')
+        raise ValueError("Invalid None value for secs")
     if not isinstance(secs, int) and len(secs) > 1:  # It's an iterable
         ss = sorted(secs)
         if min((a[1] - a[0] for a in zip(ss, ss[1:]))) < 10:
             raise ValueError("Seconds values must be >= 10s apart.")
     args = (secs, mins, hrs, mday, month, wday)  # Validation for all args
     valid = iter(_valid)
-    vestr = 'Argument {} out of range'
-    vmstr = 'Invalid no. of days for month'
+    vestr = "Argument {} out of range"
+    vmstr = "Invalid no. of days for month"
     for arg in args:  # Check for illegal arg values
         lower, upper, errtxt = next(valid)
         if isinstance(arg, int):
@@ -50,36 +91,36 @@ def cron(*, secs=0, mins=0, hrs=3, mday=None, month=None, wday=None):
     if mday is not None and month is not None:  # Check mday against month
         max_md = mday if isinstance(mday, int) else max(mday)
         if isinstance(month, int):
-            if max_md > _mdays.get(month, 31):
+            if max_md > days_in_month(month):
                 raise ValueError(vmstr)
-        elif sum((m for m in month if max_md > _mdays.get(m, 31))):
+        elif sum((m for m in month if max_md > days_in_month(m))):
             raise ValueError(vmstr)
     if mday is not None and wday is not None and do_arg(mday, 23) > 0:
-        raise ValueError('mday must be <= 22 if wday also specified.')
+        raise ValueError("mday must be <= 22 if wday also specified.")
 
     def inner(tnow):
         tev = tnow  # Time of next event: work forward from time now
-        yr, mo, md, h, m, s, wd = localtime(tev)[:7]
+        yr, mo, md, h, m, s, wd = gmtime(tev)[:7]
         init_mo = mo  # Month now
         toff = do_arg(secs, s)
         tev += toff if toff >= 0 else 60 + toff
 
-        yr, mo, md, h, m, s, wd = localtime(tev)[:7]
+        yr, mo, md, h, m, s, wd = gmtime(tev)[:7]
         toff = do_arg(mins, m)
         tev += 60 * (toff if toff >= 0 else 60 + toff)
 
-        yr, mo, md, h, m, s, wd = localtime(tev)[:7]
+        yr, mo, md, h, m, s, wd = gmtime(tev)[:7]
         toff = do_arg(hrs, h)
         tev += 3600 * (toff if toff >= 0 else 24 + toff)
 
-        yr, mo, md, h, m, s, wd = localtime(tev)[:7]
+        yr, mo, md, h, m, s, wd = gmtime(tev)[:7]
         toff = do_arg(month, mo)
         mo += toff
         md = md if mo == init_mo else 1
         if toff < 0:
             yr += 1
-        tev = mktime((yr, mo, md, h, m, s, wd, 0))
-        yr, mo, md, h, m, s, wd = localtime(tev)[:7]
+        tev = timegm((yr, mo, md, h, m, s, wd, 0))
+        yr, mo, md, h, m, s, wd = gmtime(tev)[:7]
         if mday is not None:
             if mo == init_mo:  # Month has not rolled over or been changed
                 toff = do_arg(mday, md)  # see if mday causes rollover
@@ -95,24 +136,25 @@ def cron(*, secs=0, mins=0, hrs=3, mday=None, month=None, wday=None):
         if wday is not None:
             if mo == init_mo:
                 toff = do_arg(wday, wd)
-                md += toff % 7  # mktime handles md > 31 but month may increment
-                tev = mktime((yr, mo, md, h, m, s, wd, 0))
+                md += toff % 7  # timegm handles md > 31 but month may increment
+                tev = timegm((yr, mo, md, h, m, s, wd, 0))
                 cur_mo = mo
-                mo = localtime(tev)[1]  # get month
+                mo = gmtime(tev)[1]  # get month
                 if mo != cur_mo:
                     toff = do_arg(month, mo)  # Get next valid month
                     mo += toff  # Offset is relative to new, incremented month
                     if toff < 0:
                         yr += 1
-                    tev = mktime((yr, mo, 1, h, m, s, wd, 0))  # 1st of new month
-                    yr, mo, md, h, m, s, wd = localtime(tev)[:7]  # get day of week
+                    tev = timegm((yr, mo, 1, h, m, s, wd, 0))  # 1st of new month
+                    yr, mo, md, h, m, s, wd = gmtime(tev)[:7]  # get day of week
                     toff = do_arg(wday, wd)
                     md += toff % 7
             else:
                 md = 1 if mday is None else md
-                tev = mktime((yr, mo, md, h, m, s, wd, 0))  # 1st of new month
-                yr, mo, md, h, m, s, wd = localtime(tev)[:7]  # get day of week
+                tev = timegm((yr, mo, md, h, m, s, wd, 0))  # 1st of new month
+                yr, mo, md, h, m, s, wd = gmtime(tev)[:7]  # get day of week
                 md += (do_arg(wday, 0) - wd) % 7
 
-        return mktime((yr, mo, md, h, m, s, wd, 0)) - tnow
+        return timegm((yr, mo, md, h, m, s, wd, 0)) - tnow
+
     return inner

--- a/v3/as_drivers/sched/crontest.py
+++ b/v3/as_drivers/sched/crontest.py
@@ -3,12 +3,12 @@
 # Copyright (c) 2020-2023 Peter Hinch
 # Released under the MIT License (MIT) - see LICENSE file
 
-from time import time, ticks_diff, ticks_us, localtime, mktime
-from sched.cron import cron
-import sys
+from time import ticks_diff, ticks_us, gmtime
+from sched.cron import cron, timegm
 
 maxruntime = 0
 fail = 0
+
 
 # Args:
 # ts Time of run in secs since epoch
@@ -17,8 +17,8 @@ fail = 0
 # kwargs are args for cron
 def test(ts, exp, msg, *, secs=0, mins=0, hrs=3, mday=None, month=None, wday=None):
     global maxruntime, fail
-    texp = mktime(exp + (0, 0))  # Expected absolute end time
-    yr, mo, md, h, m, s, wd = localtime(texp)[:7]
+    texp = timegm(exp + (0, 0))  # Expected absolute end time
+    yr, mo, md, h, m, s, wd = gmtime(texp)[:7]
     print(f"Test: {msg}")
     print(f"Expected endtime:  {h:02d}:{m:02d}:{s:02d} on {md:02d}/{mo:02d}/{yr:02d}")
 
@@ -27,7 +27,7 @@ def test(ts, exp, msg, *, secs=0, mins=0, hrs=3, mday=None, month=None, wday=Non
     t = cg(ts)  # Wait duration returned by cron (secs)
     delta = ticks_diff(ticks_us(), start)
     maxruntime = max(maxruntime, delta)
-    yr, mo, md, h, m, s, wd = localtime(t + ts)[:7]  # Get absolute time from cron
+    yr, mo, md, h, m, s, wd = gmtime(t + ts)[:7]  # Get absolute time from cron
     print(f"Endtime from cron: {h:02d}:{m:02d}:{s:02d} on {md:02d}/{mo:02d}/{yr:02d}")
     if t == texp - ts:
         print(f"PASS")
@@ -37,7 +37,7 @@ def test(ts, exp, msg, *, secs=0, mins=0, hrs=3, mday=None, month=None, wday=Non
     print(f"Runtime = {delta}us\n")
 
 
-now = mktime((2020, 7, 30, 3, 0, 0, 0, 0))  # 3am Thursday (day 3) 30 July 2020
+now = timegm((2020, 7, 30, 3, 0, 0, 0, 0))  # 3am Thursday (day 3) 30 July 2020
 
 exp = (2020, 7, 31, 1, 5, 0)  # Expect 01:05:00 on 31/07/2020
 msg = "wday and time both cause 1 day increment."

--- a/v3/as_drivers/sched/primitives/__init__.py
+++ b/v3/as_drivers/sched/primitives/__init__.py
@@ -10,7 +10,11 @@ async def _g():
     pass
 
 
-type_coro = type(_g())
+coro = _g()
+type_coro = type(coro)
+# Await to avoid RuntimeWarning on CPython
+asyncio.run(coro)
+
 
 # If a callback is passed, run it and return.
 # If a coro is passed initiate it and return.

--- a/v3/as_drivers/sched/sched.py
+++ b/v3/as_drivers/sched/sched.py
@@ -5,8 +5,8 @@
 
 import asyncio
 from sched.primitives import launch
-from time import time, mktime, localtime
-from sched.cron import cron
+from time import time, gmtime
+from sched.cron import cron, timegm
 
 
 # uasyncio can't handle long delays so split into 1000s (1e6 ms) segments
@@ -40,7 +40,7 @@ async def schedule(func, *args, times=None, **kwargs):
             await asyncio.sleep(min(t, _MAXT))
             t -= _MAXT
 
-    tim = mktime(localtime()[:3] + (0, 0, 0, 0, 0))  # Midnight last night
+    tim = timegm(gmtime()[:3] + (0, 0, 0, 0, 0))  # Midnight last night
     now = round(time())  # round() is for Unix
     fcron = cron(**kwargs)  # Cron instance for search.
     while tim < now:  # Find first future trigger in sequence

--- a/v3/as_drivers/sched/sched.py
+++ b/v3/as_drivers/sched/sched.py
@@ -10,10 +10,10 @@ from sched.cron import cron, timegm
 
 
 # uasyncio can't handle long delays so split into 1000s (1e6 ms) segments
-_MAXT = const(1000)
+_MAXT = 1000
 # Wait prior to a sequence start: see
 # https://github.com/peterhinch/micropython-async/blob/master/v3/docs/SCHEDULE.md#71-initialisation
-_PAUSE = const(2)
+_PAUSE = 2
 
 
 class Sequence:  # Enable asynchronous iterator interface
@@ -61,5 +61,5 @@ async def schedule(func, *args, times=None, **kwargs):
             res = launch(func, args)
         if times is not None:
             times -= 1
-        await asyncio.sleep_ms(1200)  # ensure we're into next second
+        await asyncio.sleep(_PAUSE)  # ensure we're into next second
     return res

--- a/v3/as_drivers/sched/simulate.py
+++ b/v3/as_drivers/sched/simulate.py
@@ -1,14 +1,16 @@
 # simulate.py Adapt this to simulate scheduled sequences
 
-from time import localtime, mktime
-from sched.cron import cron
+from time import gmtime
+from sched.cron import cron, timegm
 
 days = ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
 tim = 0  # Global time in secs
 
+
 def print_time(msg=""):
-    yr, mo, md, h, m, s, wd = localtime(tim)[:7]
+    yr, mo, md, h, m, s, wd = gmtime(tim)[:7]
     print(f"{msg} {h:02d}:{m:02d}:{s:02d} on {days[wd]} {md:02d}/{mo:02d}/{yr:02d}")
+
 
 def wait(cr):  # Simulate waiting on a cron instance
     global tim
@@ -20,21 +22,25 @@ def wait(cr):  # Simulate waiting on a cron instance
     tim += dt
     print_time("Time now:")
 
+
 def set_time(y, month, mday, hrs, mins, secs):
     global tim
-    tim = mktime((y, month, mday, hrs, mins, secs, 0, 0))
+    tim = timegm((y, month, mday, hrs, mins, secs, 0, 0))
     print_time("Start at:")
+
 
 # Adapt the following to emulate the proposed application. Cron args
 # secs=0, mins=0, hrs=3, mday=None, month=None, wday=None
 
+
 def sim(*args):
     set_time(*args)
-    cs = cron(hrs = 0, mins = 59)
+    cs = cron(hrs=0, mins=59)
     wait(cs)
-    cn = cron(wday=(0, 5), hrs=(1, 10), mins = range(0, 60, 15))
+    cn = cron(wday=(0, 5), hrs=(1, 10), mins=range(0, 60, 15))
     for _ in range(10):
         wait(cn)
         print("Run payload.\n")
+
 
 sim(2023, 3, 29, 15, 20, 0)  # Start time: year, month, mday, hrs, mins, secs

--- a/v3/as_drivers/sched/synctest.py
+++ b/v3/as_drivers/sched/synctest.py
@@ -4,31 +4,35 @@
 # Released under the MIT License (MIT) - see LICENSE file
 
 from .cron import cron
-from time import localtime, sleep, time
+from time import gmtime, sleep, time
+
 
 def foo(txt):
-    yr, mo, md, h, m, s, wd = localtime()[:7]
+    yr, mo, md, h, m, s, wd = gmtime()[:7]
     fst = "{} {:02d}:{:02d}:{:02d} on {:02d}/{:02d}/{:02d}"
     print(fst.format(txt, h, m, s, md, mo, yr))
 
+
 def main():
-    print('Synchronous test running...')
+    print("Synchronous test running...")
     tasks = []  # Entries: cron, callback, args, one_shot
     cron4 = cron(hrs=None, mins=range(0, 60, 4))
-    tasks.append([cron4, foo, ('every 4 mins',), False, False])
+    tasks.append([cron4, foo, ("every 4 mins",), False, False])
     cron5 = cron(hrs=None, mins=range(0, 60, 5))
-    tasks.append([cron5, foo, ('every 5 mins',), False, False])
+    tasks.append([cron5, foo, ("every 5 mins",), False, False])
     cron3 = cron(hrs=None, mins=range(0, 60, 3))
-    tasks.append([cron3, foo, ('every 3 mins',), False, False])
+    tasks.append([cron3, foo, ("every 3 mins",), False, False])
     cron2 = cron(hrs=None, mins=range(0, 60, 2))
-    tasks.append([cron2, foo, ('one shot',), True, False])
+    tasks.append([cron2, foo, ("one shot",), True, False])
     to_run = []
     while True:
         now = int(time())  # Ensure constant: get once per iteration.
-        tasks.sort(key=lambda x:x[0](now))
+        tasks.sort(key=lambda x: x[0](now))
         to_run.clear()  # Pending tasks
         deltat = tasks[0][0](now)  # Time to pending task(s)
-        for task in (t for t in tasks if t[0](now) == deltat):  # Tasks with same delta t
+        for task in (
+            t for t in tasks if t[0](now) == deltat
+        ):  # Tasks with same delta t
             to_run.append(task)
             task[4] = True  # Has been scheduled
         # Remove on-shot tasks which have been scheduled
@@ -37,5 +41,6 @@ def main():
         for tsk in to_run:
             tsk[1](*tsk[2])
         sleep(1.2)  # Ensure seconds have rolled over
+
 
 main()


### PR DESCRIPTION
This Pull Request changes the sched module from using the machine time-dependent functions `localtime()`, `timemk()` to the `gmtime()`, `timegm()` functions respectively, which use UTC. For `timegm()` a minimal implementation was added to the `cron.py` file. This would prevent items from being scheduled in a DST transition, as UTC does not do DST. This change makes the callers of `schedule` and `cron` need to use `gmtime()` and `timegm()` too, which the tests have been modified to do.

Along with this, a few minor changes were made to make the module also work on CPython, such as changing `const(n)` to `n`.