### PR TITLE
Sched: Rework to use Unix build to use UTC functions

### DIFF
--- a/v3/as_drivers/sched/asynctest.py
+++ b/v3/as_drivers/sched/asynctest.py
@@ -5,17 +5,17 @@
 
 import asyncio
 from sched.sched import schedule
-from time import localtime
+from time import gmtime
 
 
 def foo(txt):  # Demonstrate callback
-    yr, mo, md, h, m, s, wd = localtime()[:7]
+    yr, mo, md, h, m, s, wd = gmtime()[:7]
     fst = "Callback {} {:02d}:{:02d}:{:02d} on {:02d}/{:02d}/{:02d}"
     print(fst.format(txt, h, m, s, md, mo, yr))
 
 
 async def bar(txt):  # Demonstrate coro launch
-    yr, mo, md, h, m, s, wd = localtime()[:7]
+    yr, mo, md, h, m, s, wd = gmtime()[:7]
     fst = "Coroutine {} {:02d}:{:02d}:{:02d} on {:02d}/{:02d}/{:02d}"
     print(fst.format(txt, h, m, s, md, mo, yr))
     await asyncio.sleep(0)

--- a/v3/as_drivers/sched/cron.py
+++ b/v3/as_drivers/sched/cron.py
@@ -8,11 +8,58 @@
 # It holds no state.
 # See docs for restrictions and limitations.
 
-from time import mktime, localtime
+from time import gmtime, mktime
+
 # Validation
-_valid = ((0, 59, 'secs'), (0, 59, 'mins'), (0, 23, 'hrs'),
-          (1, 31, 'mday'), (1, 12, 'month'), (0, 6, 'wday'))
+_valid = (
+    (0, 59, "secs"),
+    (0, 59, "mins"),
+    (0, 23, "hrs"),
+    (1, 31, "mday"),
+    (1, 12, "month"),
+    (0, 6, "wday"),
+)
 _mdays = {2:28, 4:30, 6:30, 9:30, 11:30}
+
+
+def is_leap_year(year):
+    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
+
+
+def days_in_month(month, year=gmtime()[0]):
+    if month == 2:
+        return 29 if is_leap_year(year) else 28
+    elif month in [4, 6, 9, 11]:
+        return 30
+    else:
+        return 31
+
+
+def timegm(time_tuple):
+    """Calculate Unix timestamp from UTC."""
+
+    yr, mo, md, h, m, s = time_tuple[:6]
+
+    # calculate days since epoch
+    days = 0
+    for y in range(1970, yr):
+        days += 366 if is_leap_year(y) else 365
+    for mot in range(1, mo):
+        days += days_in_month(mot, yr)
+    days += md - 1
+
+    hours = days * 24 + h
+    minutes = hours * 60 + m
+    seconds = minutes * 60 + s
+
+    return seconds
+
+
+# Hardware build, use mktime as timegm instead
+if gmtime(0)[0] == 2000:
+    timegm = mktime
+
+
 # A call to the inner function takes 270-520μs on Pyboard depending on args
 def cron(*, secs=0, mins=0, hrs=3, mday=None, month=None, wday=None):
     # Given an arg and current value, return offset between arg and cv
@@ -27,18 +74,18 @@ def cron(*, secs=0, mins=0, hrs=3, mday=None, month=None, wday=None):
         except ValueError:  # wrap-round
             return min(a) - cv  # -ve
         except TypeError:
-            raise ValueError('Invalid argument type', type(a))
+            raise ValueError("Invalid argument type", type(a))
 
     if secs is None:  # Special validation for seconds
-        raise ValueError('Invalid None value for secs')
+        raise ValueError("Invalid None value for secs")
     if not isinstance(secs, int) and len(secs) > 1:  # It's an iterable
         ss = sorted(secs)
         if min((a[1] - a[0] for a in zip(ss, ss[1:]))) < 10:
             raise ValueError("Seconds values must be >= 10s apart.")
     args = (secs, mins, hrs, mday, month, wday)  # Validation for all args
     valid = iter(_valid)
-    vestr = 'Argument {} out of range'
-    vmstr = 'Invalid no. of days for month'
+    vestr = "Argument {} out of range"
+    vmstr = "Invalid no. of days for month"
     for arg in args:  # Check for illegal arg values
         lower, upper, errtxt = next(valid)
         if isinstance(arg, int):
@@ -55,31 +102,31 @@ def cron(*, secs=0, mins=0, hrs=3, mday=None, month=None, wday=None):
         elif sum((m for m in month if max_md > _mdays.get(m, 31))):
             raise ValueError(vmstr)
     if mday is not None and wday is not None and do_arg(mday, 23) > 0:
-        raise ValueError('mday must be <= 22 if wday also specified.')
+        raise ValueError("mday must be <= 22 if wday also specified.")
 
     def inner(tnow):
         tev = tnow  # Time of next event: work forward from time now
-        yr, mo, md, h, m, s, wd = localtime(tev)[:7]
+        yr, mo, md, h, m, s, wd = gmtime(tev)[:7]
         init_mo = mo  # Month now
         toff = do_arg(secs, s)
         tev += toff if toff >= 0 else 60 + toff
 
-        yr, mo, md, h, m, s, wd = localtime(tev)[:7]
+        yr, mo, md, h, m, s, wd = gmtime(tev)[:7]
         toff = do_arg(mins, m)
         tev += 60 * (toff if toff >= 0 else 60 + toff)
 
-        yr, mo, md, h, m, s, wd = localtime(tev)[:7]
+        yr, mo, md, h, m, s, wd = gmtime(tev)[:7]
         toff = do_arg(hrs, h)
         tev += 3600 * (toff if toff >= 0 else 24 + toff)
 
-        yr, mo, md, h, m, s, wd = localtime(tev)[:7]
+        yr, mo, md, h, m, s, wd = gmtime(tev)[:7]
         toff = do_arg(month, mo)
         mo += toff
         md = md if mo == init_mo else 1
         if toff < 0:
             yr += 1
-        tev = mktime((yr, mo, md, h, m, s, wd, 0))
-        yr, mo, md, h, m, s, wd = localtime(tev)[:7]
+        tev = timegm((yr, mo, md, h, m, s, wd, 0))
+        yr, mo, md, h, m, s, wd = gmtime(tev)[:7]
         if mday is not None:
             if mo == init_mo:  # Month has not rolled over or been changed
                 toff = do_arg(mday, md)  # see if mday causes rollover
@@ -95,24 +142,25 @@ def cron(*, secs=0, mins=0, hrs=3, mday=None, month=None, wday=None):
         if wday is not None:
             if mo == init_mo:
                 toff = do_arg(wday, wd)
-                md += toff % 7  # mktime handles md > 31 but month may increment
-                tev = mktime((yr, mo, md, h, m, s, wd, 0))
+                md += toff % 7  # timegm handles md > 31 but month may increment
+                tev = timegm((yr, mo, md, h, m, s, wd, 0))
                 cur_mo = mo
-                mo = localtime(tev)[1]  # get month
+                mo = gmtime(tev)[1]  # get month
                 if mo != cur_mo:
                     toff = do_arg(month, mo)  # Get next valid month
                     mo += toff  # Offset is relative to new, incremented month
                     if toff < 0:
                         yr += 1
-                    tev = mktime((yr, mo, 1, h, m, s, wd, 0))  # 1st of new month
-                    yr, mo, md, h, m, s, wd = localtime(tev)[:7]  # get day of week
+                    tev = timegm((yr, mo, 1, h, m, s, wd, 0))  # 1st of new month
+                    yr, mo, md, h, m, s, wd = gmtime(tev)[:7]  # get day of week
                     toff = do_arg(wday, wd)
                     md += toff % 7
             else:
                 md = 1 if mday is None else md
-                tev = mktime((yr, mo, md, h, m, s, wd, 0))  # 1st of new month
-                yr, mo, md, h, m, s, wd = localtime(tev)[:7]  # get day of week
+                tev = timegm((yr, mo, md, h, m, s, wd, 0))  # 1st of new month
+                yr, mo, md, h, m, s, wd = gmtime(tev)[:7]  # get day of week
                 md += (do_arg(wday, 0) - wd) % 7
 
-        return mktime((yr, mo, md, h, m, s, wd, 0)) - tnow
+        return timegm((yr, mo, md, h, m, s, wd, 0)) - tnow
+
     return inner

--- a/v3/as_drivers/sched/primitives/__init__.py
+++ b/v3/as_drivers/sched/primitives/__init__.py
@@ -10,7 +10,10 @@ async def _g():
     pass
 
 
-type_coro = type(_g())
+coro = _g()
+type_coro = type(coro)
+# Await to avoid RuntimeWarning on CPython
+asyncio.run(coro)
 
 # If a callback is passed, run it and return.
 # If a coro is passed initiate it and return.

--- a/v3/as_drivers/sched/sched.py
+++ b/v3/as_drivers/sched/sched.py
@@ -5,8 +5,8 @@
 
 import asyncio
 from sched.primitives import launch
-from time import time, mktime, localtime
-from sched.cron import cron
+from time import time, gmtime
+from sched.cron import cron, timegm
 
 
 # uasyncio can't handle long delays so split into 1000s (1e6 ms) segments
@@ -40,7 +40,7 @@ async def schedule(func, *args, times=None, **kwargs):
             await asyncio.sleep(min(t, _MAXT))
             t -= _MAXT
 
-    tim = mktime(localtime()[:3] + (0, 0, 0, 0, 0))  # Midnight last night
+    tim = timegm(gmtime()[:3] + (0, 0, 0, 0, 0))  # Midnight last night
     now = round(time())  # round() is for Unix
     fcron = cron(**kwargs)  # Cron instance for search.
     while tim < now:  # Find first future trigger in sequence

--- a/v3/as_drivers/sched/sched.py
+++ b/v3/as_drivers/sched/sched.py
@@ -10,10 +10,10 @@ from sched.cron import cron, timegm
 
 
 # uasyncio can't handle long delays so split into 1000s (1e6 ms) segments
-_MAXT = const(1000)
+_MAXT = 1000
 # Wait prior to a sequence start: see
 # https://github.com/peterhinch/micropython-async/blob/master/v3/docs/SCHEDULE.md#71-initialisation
-_PAUSE = const(2)
+_PAUSE = 2
 
 
 class Sequence:  # Enable asynchronous iterator interface
@@ -61,5 +61,5 @@ async def schedule(func, *args, times=None, **kwargs):
             res = launch(func, args)
         if times is not None:
             times -= 1
-        await asyncio.sleep_ms(1200)  # ensure we're into next second
+        await asyncio.sleep(_PAUSE)  # ensure we're into next second
     return res

--- a/v3/as_drivers/sched/simulate.py
+++ b/v3/as_drivers/sched/simulate.py
@@ -1,13 +1,13 @@
 # simulate.py Adapt this to simulate scheduled sequences
 
-from time import localtime, mktime
-from sched.cron import cron
+from sched.cron import cron, timegm
+from time import gmtime
 
 days = ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
 tim = 0  # Global time in secs
 
 def print_time(msg=""):
-    yr, mo, md, h, m, s, wd = localtime(tim)[:7]
+    yr, mo, md, h, m, s, wd = gmtime(tim)[:7]
     print(f"{msg} {h:02d}:{m:02d}:{s:02d} on {days[wd]} {md:02d}/{mo:02d}/{yr:02d}")
 
 def wait(cr):  # Simulate waiting on a cron instance
@@ -22,7 +22,7 @@ def wait(cr):  # Simulate waiting on a cron instance
 
 def set_time(y, month, mday, hrs, mins, secs):
     global tim
-    tim = mktime((y, month, mday, hrs, mins, secs, 0, 0))
+    tim = timegm((y, month, mday, hrs, mins, secs, 0, 0))
     print_time("Start at:")
 
 # Adapt the following to emulate the proposed application. Cron args

--- a/v3/as_drivers/sched/synctest.py
+++ b/v3/as_drivers/sched/synctest.py
@@ -4,11 +4,11 @@
 # Released under the MIT License (MIT) - see LICENSE file
 
 from .cron import cron
-from time import localtime, sleep, time
+from time import sleep, time, gmtime
 
 def foo(txt):
-    yr, mo, md, h, m, s, wd = localtime()[:7]
-    fst = "{} {:02d}:{:02d}:{:02d} on {:02d}/{:02d}/{:02d}"
+    yr, mo, md, h, m, s, wd = gmtime()[:7]
+    fst = '{} {:02d}:{:02d}:{:02d} on {:02d}/{:02d}/{:02d}'
     print(fst.format(txt, h, m, s, md, mo, yr))
 
 def main():

--- a/v3/docs/SCHEDULE.md
+++ b/v3/docs/SCHEDULE.md
@@ -163,7 +163,7 @@ supports the asynchronous iterator interface:
 ```python
 import asyncio
 from sched.sched import schedule, Sequence
-from time import localtime
+from time import gmtime
 
 async def main():
     print("Asynchronous test running...")
@@ -174,7 +174,7 @@ async def main():
     # A one-shot trigger
     asyncio.create_task(schedule(seq, 'one shot', hrs=None, mins=range(0, 60, 2), times=1))
     async for args in seq:
-        yr, mo, md, h, m, s, wd = localtime()[:7]
+        yr, mo, md, h, m, s, wd = gmtime()[:7]
         print(f"Event {h:02d}:{m:02d}:{s:02d} on {md:02d}/{mo:02d}/{yr} args: {args}")
 
 try:
@@ -300,15 +300,15 @@ This is the demo code.
 ```python
 import asyncio
 from sched.sched import schedule
-from time import localtime
+from time import gmtime
 
 def foo(txt):  # Demonstrate callback
-    yr, mo, md, h, m, s, wd = localtime()[:7]
+    yr, mo, md, h, m, s, wd = gmtime()[:7]
     fst = 'Callback {} {:02d}:{:02d}:{:02d} on {:02d}/{:02d}/{:02d}'
     print(fst.format(txt, h, m, s, md, mo, yr))
 
 async def bar(txt):  # Demonstrate coro launch
-    yr, mo, md, h, m, s, wd = localtime()[:7]
+    yr, mo, md, h, m, s, wd = gmtime()[:7]
     fst = 'Coroutine {} {:02d}:{:02d}:{:02d} on {:02d}/{:02d}/{:02d}'
     print(fst.format(txt, h, m, s, md, mo, yr))
     await asyncio.sleep(0)
@@ -339,7 +339,7 @@ in that extra positional args passed to `schedule` are lost.
 ```python
 import asyncio
 from sched.sched import schedule
-from time import localtime
+from time import gmtime
 
 async def main():
     print("Asynchronous test running...")
@@ -348,7 +348,7 @@ async def main():
     while True:
         await evt.wait()  # Multiple tasks may wait on an Event
         evt.clear()  # It must be cleared.
-        yr, mo, md, h, m, s, wd = localtime()[:7]
+        yr, mo, md, h, m, s, wd = gmtime()[:7]
         print(f"Event {h:02d}:{m:02d}:{s:02d} on {md:02d}/{mo:02d}/{yr}")
 
 try:
@@ -446,10 +446,10 @@ import sched.synctest
 This is the demo code.
 ```python
 from .cron import cron
-from time import localtime, sleep, time
+from time import gmtime, sleep, time
 
 def foo(txt):
-    yr, mo, md, h, m, s, wd = localtime()[:7]
+    yr, mo, md, h, m, s, wd = gmtime()[:7]
     fst = "{} {:02d}:{:02d}:{:02d} on {:02d}/{:02d}/{:02d}"
     print(fst.format(txt, h, m, s, md, mo, yr))
 
@@ -507,7 +507,7 @@ the first expected callback:
 
 ```python
 def wait_for(**kwargs):
-    tim = mktime(localtime()[:3] + (0, 0, 0, 0, 0))  # Midnight last night
+    tim = timegm(gmtime()[:3] + (0, 0, 0, 0, 0))  # Midnight last night
     now = round(time())
     scron = cron(**kwargs)  # Cron instance for search.
     while tim < now:  # Find first event in sequence

--- a/v3/docs/SCHEDULE.md
+++ b/v3/docs/SCHEDULE.md
@@ -216,8 +216,10 @@ Default values schedule an event every day at 03.00.00.
 ## 4.2 Calendar behaviour
 
 Specifying a day in the month which exceeds the length of a specified month
-(e.g. `month=(2, 6, 7), mday=30`) will produce a `ValueError`. February is
-assumed to have 28 days.
+(e.g. `month=(2, 6, 7), mday=30`) will produce a `ValueError`. The `mday`
+parameter assumes there are 28 days in February, but outside of this paramenter
+schedules do execute on the 29th of February (e.g. having `hrs=2` to run
+something every 2 hours will continue doing this on February 29th).
 
 ### 4.2.1 Behaviour of mday and wday values
 
@@ -271,19 +273,21 @@ depends on the complexity of the time specifiers.
 
 On hardware platforms the MicroPython `time` module does not handle daylight
 saving time. Scheduled times are relative to system time. This does not apply
-to the Unix build where daylight saving needs to be considered.
+to the Unix build where the `localtime` and `mktime` functions work with
+daylight saving time (DST). To keep consistent behavior between the Unix build
+and hardware platforms, `gmtime` and `timegm` should be used instead. An
+implementation of `timegm` is provided in the cron module.
 
 ## 4.4 The Unix build
 
 Asynchronous use requires `asyncio` V3, so ensure this is installed on the
 Linux target.
 
-The synchronous and asynchronous demos run under the Unix build. The module is
-usable on Linux provided the daylight saving time (DST) constraints are met. A
-consequence of DST is that there are impossible times when clocks go forward
-and duplicates when they go back. Scheduling those times will fail. A solution
-is to avoid scheduling the times in your region where this occurs (01.00.00 to
-02.00.00 in March and October here).
+Unlike the hardware platforms, the Unix build of micropython works with daylight
+saving (DST) and timezones when using `localtime` and `mktime` functions. To
+keep behavior consistent between platforms and to avoid issues stemming from DST
+only `gmtime` and `timegm` should be used. An implementation of `timegm` is
+provided in the cron module.
 
 ##### [Top](./SCHEDULE.md#0-contents)
 


### PR DESCRIPTION
This Pull Request makes the Unix build use the functions `gmtime` and `timegm`, which do not perform DST and work on UTC. This would avoid any issues with scheduling when a DST transition happens and makes the functionality of the Unix build the same as the Hardware builds, which do not perform DST due to constraints from using a hardware RCT.

To keep `localtime` and `mktime` on the hardware builds the module defaults to those functions if `gmtime` is unavailable, which is the case for every build outside the Unix build. To achieve this, the module is changed to use two functions `from_time` and `to_time`, which get assigned to either `localtime` and `mktime` or `gmtime` and `timegm` depending on if `gmtime` is available or not.

The documentation is updated to reflect this (4.3, 4.5), along with an updated note for calendar behavior (4.2) to state that leap years are accounted. The examples given in the documentation do still use localtime and mktime as this is normal usage on hardware builds, however, this can be changed to use `from_time` and `to_time` if desired.

Along with this, a few minor changes were made to make the module work on CPython that maintain compatibility with MicroPython.