### PR TITLE
as_drivers/nec_ir/aremote.py: bad message import #139

### DIFF
--- a/v3/as_drivers/nec_ir/aremote.py
+++ b/v3/as_drivers/nec_ir/aremote.py
@@ -6,7 +6,7 @@
 
 from sys import platform
 import asyncio
-from primitives.message import Message
+from threadsafe.message import Message
 from micropython import const
 from array import array
 from utime import ticks_ms, ticks_us, ticks_diff

--- a/v3/as_drivers/nec_ir/aremote.py
+++ b/v3/as_drivers/nec_ir/aremote.py
@@ -6,7 +6,7 @@
 
 from sys import platform
 import asyncio
-from threadsafe.message import Message
+from threadsafe import Message
 from micropython import const
 from array import array
 from utime import ticks_ms, ticks_us, ticks_diff


### PR DESCRIPTION
Commit f7c44fa in 2022 moved message from primitives to threadsafe. This reference got missed in that move.