### PR TITLE
Fix pushbutton import

### DIFF
--- a/v3/primitives/pushbutton.py
+++ b/v3/primitives/pushbutton.py
@@ -9,7 +9,7 @@ from . import launch, Delay_ms
 
 try:
     from machine import TouchPad
-except ImportError:
+except (ImportError, AttributeError):
     pass
 
 


### PR DESCRIPTION
I'm not sure why but at least on 1.27.0 on ESP32-GENERIC-S3, importing a non-existent name specifically from `machine` results in an `AttributeError`, not an `ImportError`:

```
MPY: soft reboot
MicroPython v1.27.0 on 2025-12-09; ESP32C3 module with ESP32C3
Type "help()" for more information.
>>> from machine import TouchPad
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "machine.py", line 192, in __getattr__
AttributeError: 'module' object has no attribute 'TouchPad'
```
This makes the current guard for `machine.TouchPad` ineffective, hence this PR.